### PR TITLE
memory problem solved

### DIFF
--- a/+controller/+input/+xml/EnsembleCCE_hBNLayer.xml
+++ b/+controller/+input/+xml/EnsembleCCE_hBNLayer.xml
@@ -4,10 +4,10 @@
        <SolutionName type="char">hBNLayer</SolutionName>
    </Name>
    <Condition>
-      <MagneticField type="eval">801*1e-4*[0 0 1]</MagneticField>
+      <MagneticField type="eval">806*1e-4*[0 0 1]</MagneticField>
    </Condition>
    <Dynamics>
-      <NTime type="double">21</NTime>
+      <NTime type="double">51</NTime>
       <TMax type="eval">6e-4</TMax>
       <NPulse type="double">1</NPulse>
       <CCEStrategy type='char'>ECCEClusterCoherence</CCEStrategy>
@@ -17,14 +17,14 @@
    </Interaction>
    <SpinCollection>
       <LoadSpinCollection type="double">0</LoadSpinCollection>
-      <FileName type="char">+xyz/hBNLayer100.xyz</FileName>
+      <FileName type="char">+xyz/hBNLayer1000.xyz</FileName>
       <Source type="char">File</Source>
    </SpinCollection>
    <Clustering>
        <LoadCluterIterator type="double">1</LoadCluterIterator>
-       <CluterIteratorName type="char">cluster_iterator500.mat</CluterIteratorName>
+       <CluterIteratorName type="char">cluster_iterator1000.mat</CluterIteratorName>
        <CutOff type="double">3</CutOff>
-       <MaxOrder type="double">1</MaxOrder>
+       <MaxOrder type="double">2</MaxOrder>
    </Clustering>
    <SetBathSpins>
        <SetSpin type="double">1</SetSpin>

--- a/+controller/+input/+xml/EnsembleCCE_hBNLayer.xml
+++ b/+controller/+input/+xml/EnsembleCCE_hBNLayer.xml
@@ -4,11 +4,11 @@
        <SolutionName type="char">hBNLayer</SolutionName>
    </Name>
    <Condition>
-      <MagneticField type="eval">806*1e-4*[0 0 1]</MagneticField>
+      <MagneticField type="eval">801*1e-4*[0 0 1]</MagneticField>
    </Condition>
    <Dynamics>
-      <NTime type="double">11</NTime>
-      <TMax type="eval">2e-4</TMax>
+      <NTime type="double">21</NTime>
+      <TMax type="eval">6e-4</TMax>
       <NPulse type="double">1</NPulse>
       <CCEStrategy type='char'>ECCEClusterCoherence</CCEStrategy>
    </Dynamics>
@@ -22,9 +22,9 @@
    </SpinCollection>
    <Clustering>
        <LoadCluterIterator type="double">1</LoadCluterIterator>
-       <CluterIteratorName type="char">cluster_iterator20150616_084615.mat</CluterIteratorName>
+       <CluterIteratorName type="char">cluster_iterator500.mat</CluterIteratorName>
        <CutOff type="double">3</CutOff>
-       <MaxOrder type="double">5</MaxOrder>
+       <MaxOrder type="double">1</MaxOrder>
    </Clustering>
    <SetBathSpins>
        <SetSpin type="double">1</SetSpin>

--- a/+model/+phy/+Solution/+CCESolution/+CCECoherenceStrategy/CCETotalCoherence.m
+++ b/+model/+phy/+Solution/+CCESolution/+CCECoherenceStrategy/CCETotalCoherence.m
@@ -56,7 +56,6 @@ classdef CCETotalCoherence < handle
            timelist=p.Results.timelist;
            npulse=p.Results.npulse;
            MagneticField=p.Results.magnetic_field;
-           timeTag=datestr(clock,'yyyymmdd_HHMMSS');
             
            ncluster=obj.cluster_iter.getLength;
            ntime=length(timelist);
@@ -74,14 +73,16 @@ classdef CCETotalCoherence < handle
            end
            delete(gcp('nocreate'));
            toc
-           disp('calculation of the cluster-coherence matrix finished.');
-           save([OUTPUT_FILE_PATH, 'coherence_matrix', timeTag, '.mat'],'CoherenceMatrix');
+           disp('calculation of the cluster-coherence matrix finished.');          
 
             obj.CoherenceTilde(CoherenceMatrix);
             obj.coherence.timelist=timelist;
+            
             if ncluster<20000
                 obj.coherence_matrix=CoherenceMatrix;
             else
+                timeTag=datestr(clock,'yyyymmdd_HHMMSS');
+                save([OUTPUT_FILE_PATH, 'coherence_matrix', timeTag, '.mat'],'CoherenceMatrix');
                 clear CoherenceMatrix;
             end
         end
@@ -118,12 +119,12 @@ classdef CCETotalCoherence < handle
                     cceorder=cceorder+1;
                 end
             end
-            coh.('coherence')= coh_total;
-            timeTag=datestr(clock,'yyyymmdd_HHMMSS');
-            save([OUTPUT_FILE_PATH, 'coherence_tilde_matrix', timeTag, '.mat'],'coh_tilde_mat');
+            coh.('coherence')= coh_total;            
            if ncluster<20000          
                obj.cluster_coherence_tilde_matrix=coh_tilde_mat;
            else
+               timeTag=datestr(clock,'yyyymmdd_HHMMSS');
+               save([OUTPUT_FILE_PATH, 'coherence_tilde_matrix', timeTag, '.mat'],'coh_tilde_mat');
                clear coh_tilde_mat;
            end
             obj.coherence=coh;

--- a/+model/+phy/+Solution/+CCESolution/+CCECoherenceStrategy/CCETotalCoherence.m
+++ b/+model/+phy/+Solution/+CCESolution/+CCECoherenceStrategy/CCETotalCoherence.m
@@ -5,8 +5,7 @@ classdef CCETotalCoherence < handle
         cluster_iter
         cluster_number
         cluster_coherence_strategy
-        center_spin
-        cluster_cell
+        center_spin        
         coherence_matrix
         cluster_coherence_tilde_matrix
         coherence
@@ -17,16 +16,15 @@ classdef CCETotalCoherence < handle
             obj.cluster_iter=cluster_iter;
             obj.center_spin=center_spin;
             obj.cluster_coherence_strategy=strategy;
-            obj.generate_cluster_cell();
         end
         
-        function generate_cluster_cell(obj)
+        function cluster_cell=generate_cluster_cell(obj)
             iter=obj.cluster_iter;
             ncluster=iter.cluster_info.cluster_number;
             obj.cluster_number=ncluster;
             iter.setCursor(1);
             ncluster=length(iter.index_list);
-            clu_cell=cell(1,ncluster);
+            cluster_cell=cell(1,ncluster);
 
             for n=1:ncluster
 
@@ -39,10 +37,9 @@ classdef CCETotalCoherence < handle
                strategy_name=obj.cluster_coherence_strategy;
                cluster_strategy=model.phy.Solution.CCESolution.CCECoherenceStrategy.(strategy_name);
                cluster_strategy.generate(cluster);
-               clu_cell{1,n}=cluster_strategy;
+               cluster_cell{1,n}=cluster_strategy;
 
             end
-            obj.cluster_cell=clu_cell;
         end
         
         function calculate_total_coherence(obj,center_spin_states,timelist,varargin)
@@ -59,11 +56,12 @@ classdef CCETotalCoherence < handle
            timelist=p.Results.timelist;
            npulse=p.Results.npulse;
            MagneticField=p.Results.magnetic_field;
+           timeTag=datestr(clock,'yyyymmdd_HHMMSS');
             
            ncluster=obj.cluster_iter.getLength;
            ntime=length(timelist);
            CoherenceMatrix=zeros(ncluster,ntime);
-           clu_cell=obj.cluster_cell;
+           clu_cell=obj.generate_cluster_cell();
 
            disp('calculate the cluster-coherence matrix ...');
            tic
@@ -77,7 +75,7 @@ classdef CCETotalCoherence < handle
            delete(gcp('nocreate'));
            toc
            disp('calculation of the cluster-coherence matrix finished.');
-           save([OUTPUT_FILE_PATH, 'coherence_matrix', obj.timeTag, '.mat'],'CoherenceMatrix');
+           save([OUTPUT_FILE_PATH, 'coherence_matrix', timeTag, '.mat'],'CoherenceMatrix');
 
             obj.CoherenceTilde(CoherenceMatrix);
             obj.coherence.timelist=timelist;
@@ -120,8 +118,9 @@ classdef CCETotalCoherence < handle
                     cceorder=cceorder+1;
                 end
             end
-            coh.('coherence')= coh_total; 
-            save([OUTPUT_FILE_PATH, 'coherence_tilde_matrix', obj.timeTag, '.mat'],'coh_tilde_mat');
+            coh.('coherence')= coh_total;
+            timeTag=datestr(clock,'yyyymmdd_HHMMSS');
+            save([OUTPUT_FILE_PATH, 'coherence_tilde_matrix', timeTag, '.mat'],'coh_tilde_mat');
            if ncluster<20000          
                obj.cluster_coherence_tilde_matrix=coh_tilde_mat;
            else

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 *.asv
 *.mat
 *.xyz
-*.xml
+
++controller/+input/+xml/EnsembleCCE_hBNLayer.xml
 
 +controller/+output/BenzeneDynamics20150608_122343.mat
 
 +controller/+output/ButaneDynamics20150608_122702.mat
+
 


### PR DESCRIPTION
To calculate the coherence matrix, we need to general a very big cell
containing a lot clusters, every clustter is class of
ECCEClusterCoherence.
Thus the cell became bigger and bigger after the calculation begins.
The cluster Hamiltonian, cluster coherence will be stored in the
cluster (a cluster cell element). Now, the element of the cluster cell
will be deleted after the calculation of the  corresponding cluster
coherence.

When the number of the clusters is smaller than 20000, we  do not export
the coherence matrix during the calculation.
